### PR TITLE
パラメタ引数用の型を生成

### DIFF
--- a/query.sql
+++ b/query.sql
@@ -37,3 +37,7 @@ VALUES ($1);
 -- name: AssignAuthorToBook :exec
 INSERT INTO BookAuthor (AuthorId, BookId)
 VALUES ($1, $2);
+
+-- name: GetSpongeBob :one
+SELECT character 
+FROM SpongeBobVoiceActor;

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -22,6 +22,7 @@ struct PostgresGenerator {
     enums: Vec<PostgresEnum>,
     queries: Vec<PostgresQuery>,
     return_rows: Vec<PgStruct>,
+    query_params: Vec<PgStruct>,
 }
 
 impl PostgresGenerator {
@@ -48,10 +49,17 @@ impl PostgresGenerator {
             .map(|query| PgStruct::generate_row(query, &pg_type_map))
             .collect::<Vec<_>>();
 
+        let pg_query_params = req
+            .queries
+            .iter()
+            .map(|query| PgStruct::generate_param(query, &pg_type_map))
+            .collect::<Vec<_>>();
+
         Self {
             enums: pg_enums,
             queries: pg_queries,
             return_rows: pg_return_rows,
+            query_params: pg_query_params,
         }
     }
 }
@@ -62,12 +70,14 @@ impl ToTokens for PostgresGenerator {
             enums,
             queries,
             return_rows,
+            query_params,
         } = self;
 
         tokens.extend(quote! {
             #(#enums)*
             #(#queries)*
             #(#return_rows)*
+            #(#query_params)*
         });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,8 @@ mod tests {
         dbg!(req
             .queries
             .iter()
-            // .flat_map(|q| q.columns.as_slice())
-            .take(2)
+            .flat_map(|q| q.params.as_slice())
+            .map(|p| p.column.as_ref())
             .collect::<Vec<_>>());
         dbg!(&catalog
             .schemas


### PR DESCRIPTION
Close #7

ただし、構造体が値を所有するのは都合が悪いので、関数の引数とかで受け取ったほうがいいかも