### PR TITLE
prostのデコードが失敗する問題の修正

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,10 @@ use sqlc_rust_postgres::{
 fn main() {
     let stdin = io::stdin();
     let mut stdin = stdin.lock();
-    let buffer = stdin.fill_buf().unwrap();
+    let mut buffer = Vec::new();
+    stdin.read_to_end(&mut buffer).unwrap();
 
-    let req = deserialize_codegen_request(buffer).expect("Cannot deserialize request");
+    let req = deserialize_codegen_request(&buffer).expect("Cannot deserialize request");
 
     let resp = create_codegen_response(&req).unwrap_or_else(|e| {
         eprintln!("{}", e);


### PR DESCRIPTION
大きめのクエリに対して`sqlc generate`を行うと以下のエラーが発生することがある

```bash
sqlc generate -f sqlc.json
# package rust-postgres
error generating code: 
thread 'main' panicked at src/main.rs:13:51:
Cannot deserialize request: DecodeError { description: "buffer underflow", stack: [("GenerateRequest", "queries")] }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

error: Recipe `generate` failed on line 37 with exit code 1
```

これはおそらく標準入力を読み取る個所で`fill_buf`を使っているためである。ドキュメントによると`fill_buf`はEOFまで読み切らない。そのため、prostに不完全なバッファが渡されrエラーになっていると思われる。よって代わりに`read_to_end`を使う

https://doc.rust-lang.org/std/io/trait.BufRead.html#tymethod.fill_buf