### PR TITLE
feat: improve error message for unsupported database types

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 # https://rust-lang.github.io/rustup/concepts/profiles.html
-channel = "1.85.1"
+channel = "1.87.0"
 profile = "default"

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,7 +54,7 @@ impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::Io(error) => error.fmt(f),
-            Error::InvalidRustType(rs_type) => write!(f, "{} is not valid rust type", rs_type),
+            Error::InvalidRustType(db_type) => write!(f, "Cannot find rust type that matches column type of `{}`. Add an entry to the 'overrides' section in your sqlc.json configuration.", db_type),
             Error::MissingColInfo(col_name) => {
                 write!(f, "no type information for column {}", col_name)
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,7 +54,11 @@ impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::Io(error) => error.fmt(f),
-            Error::InvalidRustType(db_type) => write!(f, "Cannot find rust type that matches column type of `{}`. Add an entry to the 'overrides' section in your sqlc.json configuration.", db_type),
+            Error::InvalidRustType(db_type) => write!(
+                f,
+                "Cannot find rust type that matches column type of `{}`. Add an entry to the 'overrides' section in your sqlc.json configuration.",
+                db_type
+            ),
             Error::MissingColInfo(col_name) => {
                 write!(f, "no type information for column {}", col_name)
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ fn main() -> ExitCode {
     match try_main() {
         Ok(_) => ExitCode::SUCCESS,
         Err(e) => {
-            eprintln!("{e:#?}");
+            eprintln!("{e}");
             ExitCode::FAILURE
         }
     }


### PR DESCRIPTION
## Summary
- Fix error message format from Debug to Display for better readability
- Improve InvalidRustType error message to provide clear guidance on using overrides configuration
- Make error messages more user-friendly and actionable

## Changes
- Changed `{e:#?}` to `{e}` in main.rs to use Display format instead of Debug
- Updated InvalidRustType error message to explain the issue and suggest solution
- Error now clearly indicates how to resolve the issue using the 'overrides' section in sqlc.json

## Test plan
- [x] Tested with unsupported database type (pg_catalog.interval)
- [x] Verified new error message is displayed correctly
- [x] Confirmed Display format is used instead of Debug format

## Before
```
error generating code: InvalidRustType(
    "pg_catalog.interval",
)
```

## After
```
error generating code: Cannot find rust type that matches column type of `pg_catalog.interval`. Add an entry to the 'overrides' section in your sqlc.json configuration.
```

Closes #39

🤖 Generated with [Claude Code](https://claude.ai/code)