### PR TITLE
feat: struct-based APIとデータベースクレート型生成の修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,14 +12,24 @@ This is `sqlc-rust-postgres`, a sqlc plugin that generates Rust code for Postgre
 - **Code Generation**: `src/codegen.rs` - Main code generation logic with `PostgresGenerator` struct
 - **Query Processing**: `src/query.rs` - Handles SQL query parsing and parameter extraction
 - **Type System**: `src/user_type.rs` - PostgreSQL to Rust type mapping with custom type overrides
+- **Database Support**: `src/db_support/` - Database-specific type handling and optimizations
+  - `column_types.rs` - Column type definitions and copy-cheap type optimizations
+  - `crate_types.rs` - Database crate abstractions (tokio_postgres, postgres, deadpool_postgres)
+- **Rust Code Generation**: `src/rust_gen/` - Rust-specific code generation modules
+  - `const_gen.rs` - SQL query constant generation
+  - `func_gen.rs` - Database function generation
+  - `param_gen.rs` - Function parameter generation with copy-cheap optimizations
+  - `struct_gen.rs` - Row struct generation
+  - `naming.rs` - Rust naming conventions and utilities
 - **Error Handling**: `src/error.rs` - Plugin-specific error types
 - **Protobuf Integration**: `src/protos/plugin/codegen.proto` - sqlc plugin protocol definitions
 
 The plugin generates:
 - Const strings for SQL queries
-- Row structs for query results
-- Async functions for database operations
+- Row structs for query results with configurable derives
+- Async functions for database operations with optimized parameter passing
 - Support for custom type overrides via configuration
+- Copy-cheap type optimizations for better performance (primitive types, database enums)
 
 ## Development Commands
 
@@ -76,6 +86,7 @@ The plugin supports these configuration options in sqlc.json:
 - `overrides`: Custom type mappings for unsupported PostgreSQL types
 - `enum_derives`: Additional derive attributes for generated enums
 - `row_derives`: Additional derive attributes for generated row structs
+- `copy_types`: Additional types that should be passed by value for better performance
 
 ## Testing Individual Examples
 
@@ -91,6 +102,76 @@ cargo test -p custom_type
 The plugin requires `protoc` (Protocol Buffers compiler) to be installed for building protobuf definitions.
 
 ## Development Best Practices
+
+### Branch Management and Pre-Commit Workflow
+**ALWAYS** create a feature branch before starting work:
+```bash
+git checkout -b feature/your-feature-name
+```
+
+**MANDATORY** checks before every commit:
+1. **Format**: `just format` - Ensure code is properly formatted
+2. **Lint**: `just lint-fix` - Fix all clippy warnings and errors
+3. **Compile**: Verify no compilation errors exist
+4. **Test**: `just test` - Ensure all tests pass
+
+**NEVER** commit code that fails any of the above checks. The codebase must always remain in a working state.
+
+### New Feature Development Process
+
+#### Requirements Analysis and Planning
+**Before implementing, always execute the following:**
+
+1. **Root Cause Analysis**
+   - Identify not just the immediate problem (e.g., `id: &i64`) but all related issues
+   - Consider similar cases (enums, user-defined types, etc.) simultaneously
+   - Map out the complete problem domain
+
+2. **Define Expected Completion State**
+   ```rust
+   // Before: get_author(client, &123, &Status::Open)
+   // After:  get_author(client, 123, Status::Open)
+   ```
+
+3. **Identify Technical Constraints**
+   - Future extensibility requirements
+   - Performance requirements (static vs dynamic dispatch)
+   - Backward compatibility with existing APIs
+
+4. **Design Comprehensive Solution**
+   - Avoid piecemeal fixes; design to solve the entire problem domain
+   - Balance configurability with automation
+   - Consider the impact on the entire system
+
+#### Implementation Process
+
+1. **Use Plan Mode for Complex Features**
+   - Always present overall design in plan mode for complex features
+   - Define specific phases with clear completion criteria
+   - Identify dependencies and potential roadblocks upfront
+
+2. **Staged but Consistent Implementation**
+   - Each stage should maintain a working state
+   - Design comprehensively upfront to avoid rework
+   - Commit at meaningful milestones (not arbitrary stopping points)
+
+3. **Validation and Feedback**
+   - Verify functionality at each stage
+   - Test with real use cases
+   - Incorporate feedback early and often
+
+#### Anti-Patterns to Avoid
+
+- **Reactive Implementation**: Solving only the immediate symptom
+- **Late Requirements**: Discovering requirements during implementation
+- **Technical Debt**: Leaving inefficient implementations (e.g., dynamic dispatch)
+- **Scope Creep**: Adding unrelated features during implementation
+
+#### Success Patterns
+
+- **Proactive Design**: Identify all related problems before coding
+- **Comprehensive Solutions**: Design to solve the entire problem domain
+- **Staged Implementation**: Comprehensive design, incremental execution
 
 ### Code Quality Workflow
 Always use `just` commands for code quality checks:
@@ -115,11 +196,13 @@ When performing refactoring or making structural changes:
 5. Fix ALL compilation errors and lint warnings before considering the work complete
 6. Never leave the codebase in a broken state - compilation and tests must pass
 
-### Testing Error Scenarios
-- Create temporary test configurations in `test_error/` directory
-- Use `_test_error_sqlc.json` with dynamic WASM SHA256 replacement
-- Build WASM plugin with `just build-wasm-dev` before testing
-- Generate dynamic config: `WASM_SHA256=$(sha256sum target/wasm32-wasip1/debug/sqlc-rust-postgres.wasm | awk '{print $1}'); sed "s/\$WASM_SHA256/${WASM_SHA256}/g" config_template.json > actual_config.json`
+### Pull Request Workflow
+Before creating a PR:
+1. **Branch**: Work on a feature branch (never directly on main)
+2. **Quality**: Run the mandatory pre-commit checks (format, lint, compile, test)
+3. **Generate**: Run `just generate` to ensure WASM builds and code generation works
+4. **Push**: Push the feature branch to remote
+5. **PR**: Create PR with descriptive title and comprehensive description
 
 ### CI/CD Integration
 - Always run `just format` and `just lint-fix` before pushing

--- a/docs/struct-based-api.md
+++ b/docs/struct-based-api.md
@@ -1,0 +1,380 @@
+# Struct-Based API Design and Implementation
+
+## 概要
+
+本文書では、sqlc-rust-postgresプラグインにおける構造体ベースAPI（Struct-Based API）の設計、実装戦略、および技術的判断の根拠について詳述する。この機能は、現在の関数ベースAPIの課題を解決しつつ、ゼロコスト抽象化を実現する新しいAPIパターンを提供する。
+
+## 背景と問題意識
+
+### 現在の課題
+
+現在のsqlc-rust-postgresプラグインが生成するAPIには、以下の重要な問題がある：
+
+#### 1. 関数引数の肥大化問題
+
+SQLクエリのパラメータが増加すると、生成される関数の引数が過度に多くなる：
+
+```rust
+// 問題のある例：引数が多すぎて可読性・保守性が低い
+pub async fn update_user_profile(
+    client: &Client,
+    user_id: i64,
+    name: &str,
+    email: &str,
+    phone: &str,
+    address: &str,
+    birth_date: Option<chrono::NaiveDate>,
+    is_verified: bool,
+    updated_at: chrono::DateTime<chrono::Utc>,
+) -> Result<UpdateUserProfileRow, Error>
+```
+
+#### 2. パラメータ順序の誤用リスク
+
+引数の順序は型システムでは検証されないため、SQLクエリの変更により引数順序が変わっても、型が一致していればコンパイルエラーにならない：
+
+```rust
+// SQLクエリ変更前：WHERE user_id = $1 AND status = $2
+get_user_by_status(client, user_id, status).await?;
+
+// SQLクエリ変更後：WHERE status = $1 AND user_id = $2  
+// ↓ 引数順序が入れ替わったが、型は同じなのでコンパイルエラーにならない
+get_user_by_status(client, user_id, status).await?; // バグ！
+```
+
+#### 3. 型安全性の欠如
+
+関数の引数リストでは、どの値がどのSQLパラメータに対応するかが位置に依存するため、リファクタリング時の安全性が低い。
+
+### 解決すべき要求仕様
+
+上記課題を踏まえ、以下の要求仕様を満たすAPIを設計する：
+
+1. **型安全性の向上**: パラメータの設定漏れや重複設定をコンパイル時に検出
+2. **可読性の向上**: どの値がどのパラメータに対応するかが明確
+3. **保守性の向上**: SQLクエリの変更に対してより堅牢
+4. **パフォーマンス**: ゼロコスト抽象化の実現
+5. **後方互換性**: 既存APIを破壊しない
+
+## 設計アプローチ
+
+### 基本設計思想
+
+本実装では **型状態パターン（Type State Pattern）** を採用し、以下の原則に基づいて設計する：
+
+#### 1. コンパイル時安全性の最大化
+
+Rustの型システムを活用し、実行時エラーを可能な限りコンパイル時エラーに変換する：
+
+```rust
+// コンパイル時に全パラメータの設定を強制
+let query = GetUser::builder()
+    .user_id(123)          // 必須パラメータ
+    .include_deleted(false) // 必須パラメータ
+    .build();              // 全パラメータ設定済みの場合のみコンパイル成功
+```
+
+#### 2. ゼロコスト抽象化の実現
+
+builderパターンの実装において、実行時コストを排除する：
+
+- `Option<T>`を使わずに型状態でフィールドの設定状態を管理
+- `unwrap()`等の実行時チェックを排除
+- 最終的な`build()`メソッドは単純なメモリ操作のみ
+
+#### 3. copy_types最適化の統合
+
+既存の`copy_types`設定と連携し、パラメータの渡し方を最適化する：
+
+- Copy型（i32, bool等）: 値渡しで効率化
+- 非Copy型（String等）: `Cow<'a, T>`で借用/所有を適応的に選択
+
+## 実装戦略
+
+### 1. 型状態パターンの実装
+
+#### 基本構造
+
+```rust
+// クエリパラメータを保持する最終構造体
+pub struct GetUser<'a> {
+    user_id: i32,                    // Copy型：値渡し
+    name: Cow<'a, str>,             // 非Copy型：Cowで最適化
+}
+
+// 型状態を管理するbuilder
+pub struct GetUserBuilder<'a, Fields = ((), ())> {
+    fields: Fields,                  // 実際の値を型レベルで管理
+    phantom: PhantomData<&'a ()>,   // ライフタイム保持
+}
+```
+
+#### 段階的型状態の変化
+
+```rust
+// 初期状態：未設定
+GetUserBuilder<'a, ((), ())>
+
+// user_id設定後：第1フィールドのみ設定済み
+GetUserBuilder<'a, (i32, ())>
+
+// name設定後：全フィールド設定済み
+GetUserBuilder<'a, (i32, Cow<'a, str>)>
+```
+
+#### ゼロコストbuilder実装
+
+```rust
+impl<'a, V2> GetUserBuilder<'a, ((), V2)> {
+    pub fn user_id(self, user_id: i32) -> GetUserBuilder<'a, (i32, V2)> {
+        let ((), name) = self.fields;
+        GetUserBuilder {
+            fields: (user_id, name),  // 単純な値の移動のみ
+            phantom: PhantomData,
+        }
+    }
+}
+
+// build()メソッド：unwrap()なしの単純なdestructuring
+impl<'a> GetUserBuilder<'a, (i32, Cow<'a, str>)> {
+    pub fn build(self) -> GetUser<'a> {
+        let (user_id, name) = self.fields;  // ゼロコスト
+        GetUser { user_id, name }
+    }
+}
+```
+
+### 2. QueryAnnotationに基づく実行メソッド
+
+SQLCのクエリアノテーションに基づいて、適切な実行メソッドを生成する：
+
+```rust
+impl<'a> GetUser<'a> {
+    // :one アノテーション → query_one & query_opt
+    pub async fn query_one(&self, client: &Client) -> Result<UserRow, Error>
+    pub async fn query_opt(&self, client: &Client) -> Result<Option<UserRow>, Error>
+    
+    // :many アノテーション → query_many & query_raw  
+    pub async fn query_many(&self, client: &Client) -> Result<Vec<UserRow>, Error>
+    pub async fn query_raw(&self, client: &Client) -> Result<impl Iterator<Item=Result<UserRow, Error>>, Error>
+    
+    // :exec アノテーション → execute
+    pub async fn execute(&self, client: &Client) -> Result<u64, Error>
+}
+```
+
+### 3. copy_types最適化の統合
+
+既存の`copy_types`設定と統合し、型ごとに最適なパラメータ渡しを実現する：
+
+#### 自動判定ルール
+
+1. **Copy trait実装型かつ16バイト以下**: 値渡し
+2. **String系**: `Cow<'a, str>`で最適化
+3. **ユーザー定義copy_types**: 設定に従って値渡し
+4. **その他**: 参照渡し
+
+#### 実装例
+
+```rust
+// 生成される構造体（copy_types最適化適用後）
+pub struct CreateUser<'a> {
+    id: i32,                        // Copy型：値渡し
+    name: Cow<'a, str>,            // 文字列：Cowで最適化
+    email: Cow<'a, str>,           // 文字列：Cowで最適化
+    is_active: bool,               // Copy型：値渡し
+    metadata: &'a serde_json::Value, // 大きな型：参照渡し
+}
+```
+
+## 後方互換性戦略
+
+### 既存APIの保持
+
+新しい構造体ベースAPIは**追加機能**として実装し、既存の関数ベースAPIを破壊しない：
+
+```rust
+// 既存API：そのまま維持（内部実装のみ最適化）
+pub async fn get_user(client: &Client, user_id: i32, name: &str) -> Result<UserRow, Error> {
+    // 内部でGetUser構造体を使用（外部には露出しない）
+    let query = GetUser {
+        user_id,
+        name: Cow::Borrowed(name),
+    };
+    query.query_one(client).await
+}
+
+// 新しいAPI：オプションとして提供
+let user = GetUser::builder()
+    .user_id(123)
+    .name("test")
+    .build()
+    .query_one(&client)
+    .await?;
+```
+
+### 段階的移行戦略
+
+1. **フェーズ1**: 構造体ベースAPIの実装と検証
+2. **フェーズ2**: ドキュメント整備とサンプル提供
+3. **フェーズ3**: ユーザーフィードバックに基づく改善
+4. **フェーズ4**: 既存APIの非推奨化（長期計画）
+
+## 実装の技術的詳細
+
+### 1. コード生成フロー
+
+```
+SQL解析 → パラメータ抽出 → copy_types適用 → 構造体生成 → builder生成 → 実行メソッド生成
+```
+
+#### 主要な生成フェーズ
+
+1. **パラメータ分析**: SQLクエリからパラメータを抽出
+2. **型最適化**: copy_types設定に基づく型変換
+3. **構造体生成**: 最適化された型でクエリ構造体を生成
+4. **builder生成**: 型状態パターンでbuilderを生成
+5. **メソッド生成**: QueryAnnotationに基づく実行メソッド生成
+
+### 2. 実装上の制約と対処
+
+#### 制約1: Rustの型システムの限界
+
+**問題**: タプルの要素数には限界があるため、極端に多いパラメータを持つクエリでは型状態パターンが適用できない。
+
+**対処**: パラメータ数が閾値（例：16個）を超える場合は、従来の`Option<T>`ベースのbuilderにフォールバック。
+
+#### 制約2: ライフタイム管理の複雑さ
+
+**問題**: 複数の借用パラメータが存在する場合、ライフタイム管理が複雑になる。
+
+**対処**: 
+- `PhantomData<&'a ()>`でライフタイムを統一
+- 必要に応じて複数ライフタイムパラメータを使用
+- `Cow<'a, T>`で借用と所有を適応的に切り替え
+
+### 3. パフォーマンス考慮事項
+
+#### ゼロコスト抽象化の検証
+
+以下の観点でパフォーマンスを検証する：
+
+1. **コンパイル時最適化**: リリースビルドでbuilderパターンが完全に最適化されるか
+2. **メモリ使用量**: 構造体のメモリレイアウトが効率的か
+3. **実行時コスト**: 従来の関数型APIと比較して性能劣化がないか
+
+#### 最適化指針
+
+```rust
+// 最適化前（実行時コストあり）
+struct Builder {
+    user_id: Option<i32>,    // Option型によるオーバーヘッド
+    name: Option<String>,    // unwrap()による実行時チェック
+}
+
+// 最適化後（ゼロコスト）
+struct Builder<Fields = ((), ())> {
+    fields: Fields,          // 型レベルでの状態管理
+    phantom: PhantomData<()>, // コンパイル時のみ
+}
+```
+
+## 設定オプションの拡張
+
+### 既存設定の活用
+
+構造体ベースAPIは既存の`copy_types`設定を活用し、新たな設定項目は追加しない方針とする。これにより設定の複雑化を避け、シンプルな利用体験を維持する。
+
+```json
+{
+  "plugins": [
+    {
+      "name": "rust-postgres", 
+      "options": {
+        "copy_types": ["uuid::Uuid", "CustomId"],
+        "existing_options": "..."
+      }
+    }
+  ]
+}
+```
+
+## 今後の拡張計画
+
+### 短期計画（3ヶ月以内）
+
+1. **基本実装の完成**: 型状態パターンの実装
+2. **copy_types統合**: 既存最適化との連携
+3. **テストケース整備**: 包括的なテストスイート
+4. **ドキュメント整備**: API仕様とサンプルコード
+
+### 中期計画（6ヶ月以内）
+
+1. **エラーメッセージ改善**: コンパイルエラーの分かりやすさ向上
+2. **IDE統合**: rust-analyzerでの補完とエラー表示改善
+3. **パフォーマンス検証**: ベンチマークとプロファイリング
+4. **エコシステム対応**: 主要なPostgreSQLクレートとの互換性確認
+
+### 長期計画（1年以内）
+
+1. **バッチ操作対応**: BatchExec等のアノテーション対応
+2. **トランザクション統合**: 型安全なトランザクション管理
+3. **マイグレーション支援**: 既存コードの移行ツール
+4. **他データベース対応**: MySQL、SQLite等への展開
+
+## リスク分析と対策
+
+### 技術的リスク
+
+#### リスク1: コンパイル時間の増加
+
+**原因**: 複雑な型状態パターンによるコンパイル負荷増加
+
+**対策**: 
+- 型の複雑さを適切に制限
+- インクリメンタルコンパイルの最適化
+- 必要に応じてマクロによる実装簡素化
+
+#### リスク2: エラーメッセージの複雑化
+
+**原因**: 型状態パターンの型エラーが分かりにくい
+
+**対策**:
+- 適切な型エイリアスの提供
+- カスタムコンパイルエラーメッセージ
+- 詳細なドキュメントと例示
+
+### 採用リスク
+
+#### リスク1: 学習コストの増加
+
+**原因**: 新しいAPIパターンの習得が必要
+
+**対策**:
+- 段階的な移行計画
+- 豊富なサンプルコードとチュートリアル
+- 既存APIとの併用期間の確保
+
+#### リスク2: エコシステムの分断
+
+**原因**: 新旧APIの並存による混乱
+
+**対策**:
+- 明確な移行ガイドライン
+- ツールによる自動変換支援
+- コミュニティとの十分な対話
+
+## 結論
+
+構造体ベースAPIの導入により、以下の価値を提供できる：
+
+1. **開発者体験の向上**: 型安全性と可読性の大幅な改善
+2. **保守性の向上**: SQLクエリ変更に対する堅牢性
+3. **パフォーマンス**: ゼロコスト抽象化による効率性
+4. **段階的移行**: 既存コードへの影響を最小化
+
+本実装は、Rustの型システムの力を最大限に活用し、データベースアクセスレイヤーの安全性と効率性を大幅に向上させる重要な機能である。慎重な実装と十分な検証を通じて、sqlc-rust-postgresプラグインの価値を更に高めることができると確信している。
+
+---
+
+*本文書の内容は実装の進行に伴い更新される予定である。最新の情報については、GitHubのissueとPRを参照されたい。*

--- a/examples/complex_queries/src/queries.rs
+++ b/examples/complex_queries/src/queries.rs
@@ -29,6 +29,21 @@ pub struct GetBookWithAuthorAndCategoriesRow {
     pub categories_name: String,
     pub description: Option<String>,
 }
+impl GetBookWithAuthorAndCategoriesRow {
+    pub(crate) fn from_row(row: &tokio_postgres::Row) -> Result<Self, tokio_postgres::Error> {
+        Ok(GetBookWithAuthorAndCategoriesRow {
+            books_id: row.try_get(0)?,
+            title: row.try_get(1)?,
+            published_year: row.try_get(2)?,
+            authors_id: row.try_get(3)?,
+            authors_name: row.try_get(4)?,
+            birth_year: row.try_get(5)?,
+            categories_id: row.try_get(6)?,
+            categories_name: row.try_get(7)?,
+            description: row.try_get(8)?,
+        })
+    }
+}
 pub async fn get_book_with_author_and_categories(
     client: &impl tokio_postgres::GenericClient,
     published_year: Option<i32>,
@@ -39,19 +54,54 @@ pub async fn get_book_with_author_and_categories(
     let rows = client
         .query(GET_BOOK_WITH_AUTHOR_AND_CATEGORIES, &[&published_year])
         .await?;
-    Ok(rows.into_iter().map(|r| {
-        Ok(GetBookWithAuthorAndCategoriesRow {
-            books_id: r.try_get(0)?,
-            title: r.try_get(1)?,
-            published_year: r.try_get(2)?,
-            authors_id: r.try_get(3)?,
-            authors_name: r.try_get(4)?,
-            birth_year: r.try_get(5)?,
-            categories_id: r.try_get(6)?,
-            categories_name: r.try_get(7)?,
-            description: r.try_get(8)?,
-        })
-    }))
+    Ok(rows
+        .into_iter()
+        .map(|r| GetBookWithAuthorAndCategoriesRow::from_row(&r)))
+}
+#[derive(Debug)]
+pub struct GetBookWithAuthorAndCategories {
+    pub published_year: Option<i32>,
+}
+impl GetBookWithAuthorAndCategories {
+    pub const QUERY: &'static str = r#"-- name: GetBookWithAuthorAndCategories :many
+SELECT 
+    b.id,
+    b.title,
+    b.published_year,
+    a.id,
+    a.name,
+    a.birth_year,
+    c.id,
+    c.name,
+    c.description
+FROM books b
+JOIN authors a ON b.author_id = a.id
+JOIN book_categories bc ON b.id = bc.book_id
+JOIN categories c ON bc.category_id = c.id
+WHERE b.published_year > $1"#;
+}
+impl GetBookWithAuthorAndCategories {
+    pub async fn query_many(
+        &self,
+        client: &impl tokio_postgres::GenericClient,
+    ) -> Result<Vec<GetBookWithAuthorAndCategoriesRow>, tokio_postgres::Error> {
+        let rows = client.query(Self::QUERY, &[&self.published_year]).await?;
+        rows.into_iter()
+            .map(|r| GetBookWithAuthorAndCategoriesRow::from_row(&r))
+            .collect()
+    }
+    pub async fn query_raw(
+        &self,
+        client: &impl tokio_postgres::GenericClient,
+    ) -> Result<
+        impl Iterator<Item = Result<GetBookWithAuthorAndCategoriesRow, tokio_postgres::Error>>,
+        tokio_postgres::Error,
+    > {
+        let rows = client.query(Self::QUERY, &[&self.published_year]).await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| GetBookWithAuthorAndCategoriesRow::from_row(&r)))
+    }
 }
 pub const GET_EMPLOYEES_WITH_MANAGERS: &str = r#"-- name: GetEmployeesWithManagers :many
 SELECT 
@@ -74,6 +124,19 @@ pub struct GetEmployeesWithManagersRow {
     pub employees_name_2: Option<String>,
     pub employees_department_2: Option<String>,
 }
+impl GetEmployeesWithManagersRow {
+    pub(crate) fn from_row(row: &tokio_postgres::Row) -> Result<Self, tokio_postgres::Error> {
+        Ok(GetEmployeesWithManagersRow {
+            employees_id_1: row.try_get(0)?,
+            employees_name_1: row.try_get(1)?,
+            employees_department_1: row.try_get(2)?,
+            salary: row.try_get(3)?,
+            employees_id_2: row.try_get(4)?,
+            employees_name_2: row.try_get(5)?,
+            employees_department_2: row.try_get(6)?,
+        })
+    }
+}
 pub async fn get_employees_with_managers(
     client: &impl tokio_postgres::GenericClient,
 ) -> Result<
@@ -81,17 +144,9 @@ pub async fn get_employees_with_managers(
     tokio_postgres::Error,
 > {
     let rows = client.query(GET_EMPLOYEES_WITH_MANAGERS, &[]).await?;
-    Ok(rows.into_iter().map(|r| {
-        Ok(GetEmployeesWithManagersRow {
-            employees_id_1: r.try_get(0)?,
-            employees_name_1: r.try_get(1)?,
-            employees_department_1: r.try_get(2)?,
-            salary: r.try_get(3)?,
-            employees_id_2: r.try_get(4)?,
-            employees_name_2: r.try_get(5)?,
-            employees_department_2: r.try_get(6)?,
-        })
-    }))
+    Ok(rows
+        .into_iter()
+        .map(|r| GetEmployeesWithManagersRow::from_row(&r)))
 }
 pub const GET_TOP_RATED_BOOKS: &str = r#"-- name: GetTopRatedBooks :many
 SELECT id, title, published_year
@@ -107,6 +162,15 @@ pub struct GetTopRatedBooksRow {
     pub title: String,
     pub published_year: Option<i32>,
 }
+impl GetTopRatedBooksRow {
+    pub(crate) fn from_row(row: &tokio_postgres::Row) -> Result<Self, tokio_postgres::Error> {
+        Ok(GetTopRatedBooksRow {
+            id: row.try_get(0)?,
+            title: row.try_get(1)?,
+            published_year: row.try_get(2)?,
+        })
+    }
+}
 pub async fn get_top_rated_books(
     client: &impl tokio_postgres::GenericClient,
     rating: Option<i32>,
@@ -115,13 +179,42 @@ pub async fn get_top_rated_books(
     tokio_postgres::Error,
 > {
     let rows = client.query(GET_TOP_RATED_BOOKS, &[&rating]).await?;
-    Ok(rows.into_iter().map(|r| {
-        Ok(GetTopRatedBooksRow {
-            id: r.try_get(0)?,
-            title: r.try_get(1)?,
-            published_year: r.try_get(2)?,
-        })
-    }))
+    Ok(rows.into_iter().map(|r| GetTopRatedBooksRow::from_row(&r)))
+}
+#[derive(Debug)]
+pub struct GetTopRatedBooks {
+    pub rating: Option<i32>,
+}
+impl GetTopRatedBooks {
+    pub const QUERY: &'static str = r#"-- name: GetTopRatedBooks :many
+SELECT id, title, published_year
+FROM books
+WHERE id IN (
+    SELECT book_id 
+    FROM reviews 
+    WHERE rating >= $1
+)"#;
+}
+impl GetTopRatedBooks {
+    pub async fn query_many(
+        &self,
+        client: &impl tokio_postgres::GenericClient,
+    ) -> Result<Vec<GetTopRatedBooksRow>, tokio_postgres::Error> {
+        let rows = client.query(Self::QUERY, &[&self.rating]).await?;
+        rows.into_iter()
+            .map(|r| GetTopRatedBooksRow::from_row(&r))
+            .collect()
+    }
+    pub async fn query_raw(
+        &self,
+        client: &impl tokio_postgres::GenericClient,
+    ) -> Result<
+        impl Iterator<Item = Result<GetTopRatedBooksRow, tokio_postgres::Error>>,
+        tokio_postgres::Error,
+    > {
+        let rows = client.query(Self::QUERY, &[&self.rating]).await?;
+        Ok(rows.into_iter().map(|r| GetTopRatedBooksRow::from_row(&r)))
+    }
 }
 pub const GET_AUTHOR_BOOK_STATS: &str = r#"-- name: GetAuthorBookStats :many
 SELECT 
@@ -146,6 +239,18 @@ pub struct GetAuthorBookStatsRow {
     pub books_id: Option<i32>,
     pub title: Option<String>,
 }
+impl GetAuthorBookStatsRow {
+    pub(crate) fn from_row(row: &tokio_postgres::Row) -> Result<Self, tokio_postgres::Error> {
+        Ok(GetAuthorBookStatsRow {
+            authors_id: row.try_get(0)?,
+            name: row.try_get(1)?,
+            book_count: row.try_get(2)?,
+            avg_rating: row.try_get(3)?,
+            books_id: row.try_get(4)?,
+            title: row.try_get(5)?,
+        })
+    }
+}
 pub async fn get_author_book_stats(
     client: &impl tokio_postgres::GenericClient,
     id: i32,
@@ -154,16 +259,52 @@ pub async fn get_author_book_stats(
     tokio_postgres::Error,
 > {
     let rows = client.query(GET_AUTHOR_BOOK_STATS, &[&id]).await?;
-    Ok(rows.into_iter().map(|r| {
-        Ok(GetAuthorBookStatsRow {
-            authors_id: r.try_get(0)?,
-            name: r.try_get(1)?,
-            book_count: r.try_get(2)?,
-            avg_rating: r.try_get(3)?,
-            books_id: r.try_get(4)?,
-            title: r.try_get(5)?,
-        })
-    }))
+    Ok(rows
+        .into_iter()
+        .map(|r| GetAuthorBookStatsRow::from_row(&r)))
+}
+#[derive(Debug)]
+pub struct GetAuthorBookStats {
+    pub id: i32,
+}
+impl GetAuthorBookStats {
+    pub const QUERY: &'static str = r#"-- name: GetAuthorBookStats :many
+SELECT 
+    a.id,
+    a.name,
+    COUNT(DISTINCT b.id) as book_count,
+    AVG(r.rating) as avg_rating,
+    b.id,
+    b.title
+FROM authors a
+LEFT JOIN books b ON a.id = b.author_id
+LEFT JOIN reviews r ON b.id = r.book_id
+WHERE b.id IS NOT NULL
+GROUP BY a.id, a.name, b.id, b.title
+HAVING COUNT(DISTINCT b.id) > $1"#;
+}
+impl GetAuthorBookStats {
+    pub async fn query_many(
+        &self,
+        client: &impl tokio_postgres::GenericClient,
+    ) -> Result<Vec<GetAuthorBookStatsRow>, tokio_postgres::Error> {
+        let rows = client.query(Self::QUERY, &[&self.id]).await?;
+        rows.into_iter()
+            .map(|r| GetAuthorBookStatsRow::from_row(&r))
+            .collect()
+    }
+    pub async fn query_raw(
+        &self,
+        client: &impl tokio_postgres::GenericClient,
+    ) -> Result<
+        impl Iterator<Item = Result<GetAuthorBookStatsRow, tokio_postgres::Error>>,
+        tokio_postgres::Error,
+    > {
+        let rows = client.query(Self::QUERY, &[&self.id]).await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| GetAuthorBookStatsRow::from_row(&r)))
+    }
 }
 pub const COMPARE_BOOK_YEARS: &str = r#"-- name: CompareBookYears :many
 SELECT 
@@ -188,6 +329,18 @@ pub struct CompareBookYearsRow {
     pub books_title_2: String,
     pub books_published_year_2: Option<i32>,
 }
+impl CompareBookYearsRow {
+    pub(crate) fn from_row(row: &tokio_postgres::Row) -> Result<Self, tokio_postgres::Error> {
+        Ok(CompareBookYearsRow {
+            books_id_1: row.try_get(0)?,
+            books_title_1: row.try_get(1)?,
+            books_published_year_1: row.try_get(2)?,
+            books_id_2: row.try_get(3)?,
+            books_title_2: row.try_get(4)?,
+            books_published_year_2: row.try_get(5)?,
+        })
+    }
+}
 pub async fn compare_book_years(
     client: &impl tokio_postgres::GenericClient,
     published_year_1: Option<i32>,
@@ -199,16 +352,59 @@ pub async fn compare_book_years(
     let rows = client
         .query(COMPARE_BOOK_YEARS, &[&published_year_1, &published_year_2])
         .await?;
-    Ok(rows.into_iter().map(|r| {
-        Ok(CompareBookYearsRow {
-            books_id_1: r.try_get(0)?,
-            books_title_1: r.try_get(1)?,
-            books_published_year_1: r.try_get(2)?,
-            books_id_2: r.try_get(3)?,
-            books_title_2: r.try_get(4)?,
-            books_published_year_2: r.try_get(5)?,
-        })
-    }))
+    Ok(rows.into_iter().map(|r| CompareBookYearsRow::from_row(&r)))
+}
+#[derive(Debug)]
+pub struct CompareBookYears {
+    pub published_year_1: Option<i32>,
+    pub published_year_2: Option<i32>,
+}
+impl CompareBookYears {
+    pub const QUERY: &'static str = r#"-- name: CompareBookYears :many
+SELECT 
+    old_books.id,
+    old_books.title,
+    old_books.published_year,
+    new_books.id,
+    new_books.title,
+    new_books.published_year
+FROM books old_books
+CROSS JOIN books new_books
+WHERE old_books.published_year < $1 
+  AND new_books.published_year > $2
+  AND old_books.id != new_books.id
+LIMIT 10"#;
+}
+impl CompareBookYears {
+    pub async fn query_many(
+        &self,
+        client: &impl tokio_postgres::GenericClient,
+    ) -> Result<Vec<CompareBookYearsRow>, tokio_postgres::Error> {
+        let rows = client
+            .query(
+                Self::QUERY,
+                &[&self.published_year_1, &self.published_year_2],
+            )
+            .await?;
+        rows.into_iter()
+            .map(|r| CompareBookYearsRow::from_row(&r))
+            .collect()
+    }
+    pub async fn query_raw(
+        &self,
+        client: &impl tokio_postgres::GenericClient,
+    ) -> Result<
+        impl Iterator<Item = Result<CompareBookYearsRow, tokio_postgres::Error>>,
+        tokio_postgres::Error,
+    > {
+        let rows = client
+            .query(
+                Self::QUERY,
+                &[&self.published_year_1, &self.published_year_2],
+            )
+            .await?;
+        Ok(rows.into_iter().map(|r| CompareBookYearsRow::from_row(&r)))
+    }
 }
 pub const GET_BOOKS_WITH_ALIASES: &str = r#"-- name: GetBooksWithAliases :many
 SELECT 
@@ -222,6 +418,15 @@ pub struct GetBooksWithAliasesRow {
     pub book_id: i32,
     pub book_title: String,
     pub year: Option<i32>,
+}
+impl GetBooksWithAliasesRow {
+    pub(crate) fn from_row(row: &tokio_postgres::Row) -> Result<Self, tokio_postgres::Error> {
+        Ok(GetBooksWithAliasesRow {
+            book_id: row.try_get(0)?,
+            book_title: row.try_get(1)?,
+            year: row.try_get(2)?,
+        })
+    }
 }
 pub async fn get_books_with_aliases(
     client: &impl tokio_postgres::GenericClient,
@@ -237,13 +442,56 @@ pub async fn get_books_with_aliases(
             &[&published_year_1, &published_year_2],
         )
         .await?;
-    Ok(rows.into_iter().map(|r| {
-        Ok(GetBooksWithAliasesRow {
-            book_id: r.try_get(0)?,
-            book_title: r.try_get(1)?,
-            year: r.try_get(2)?,
-        })
-    }))
+    Ok(rows
+        .into_iter()
+        .map(|r| GetBooksWithAliasesRow::from_row(&r)))
+}
+#[derive(Debug)]
+pub struct GetBooksWithAliases {
+    pub published_year_1: Option<i32>,
+    pub published_year_2: Option<i32>,
+}
+impl GetBooksWithAliases {
+    pub const QUERY: &'static str = r#"-- name: GetBooksWithAliases :many
+SELECT 
+    id as book_id,
+    title as book_title,
+    published_year as year
+FROM books
+WHERE published_year BETWEEN $1 AND $2"#;
+}
+impl GetBooksWithAliases {
+    pub async fn query_many(
+        &self,
+        client: &impl tokio_postgres::GenericClient,
+    ) -> Result<Vec<GetBooksWithAliasesRow>, tokio_postgres::Error> {
+        let rows = client
+            .query(
+                Self::QUERY,
+                &[&self.published_year_1, &self.published_year_2],
+            )
+            .await?;
+        rows.into_iter()
+            .map(|r| GetBooksWithAliasesRow::from_row(&r))
+            .collect()
+    }
+    pub async fn query_raw(
+        &self,
+        client: &impl tokio_postgres::GenericClient,
+    ) -> Result<
+        impl Iterator<Item = Result<GetBooksWithAliasesRow, tokio_postgres::Error>>,
+        tokio_postgres::Error,
+    > {
+        let rows = client
+            .query(
+                Self::QUERY,
+                &[&self.published_year_1, &self.published_year_2],
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| GetBooksWithAliasesRow::from_row(&r)))
+    }
 }
 pub const GET_CATEGORY_STATS: &str = r#"-- name: GetCategoryStats :many
 SELECT 
@@ -267,6 +515,17 @@ pub struct GetCategoryStatsRow {
     pub author_count: i64,
     pub avg_rating: f64,
 }
+impl GetCategoryStatsRow {
+    pub(crate) fn from_row(row: &tokio_postgres::Row) -> Result<Self, tokio_postgres::Error> {
+        Ok(GetCategoryStatsRow {
+            id: row.try_get(0)?,
+            name: row.try_get(1)?,
+            book_count: row.try_get(2)?,
+            author_count: row.try_get(3)?,
+            avg_rating: row.try_get(4)?,
+        })
+    }
+}
 pub async fn get_category_stats(
     client: &impl tokio_postgres::GenericClient,
 ) -> Result<
@@ -274,13 +533,5 @@ pub async fn get_category_stats(
     tokio_postgres::Error,
 > {
     let rows = client.query(GET_CATEGORY_STATS, &[]).await?;
-    Ok(rows.into_iter().map(|r| {
-        Ok(GetCategoryStatsRow {
-            id: r.try_get(0)?,
-            name: r.try_get(1)?,
-            book_count: r.try_get(2)?,
-            author_count: r.try_get(3)?,
-            avg_rating: r.try_get(4)?,
-        })
-    }))
+    Ok(rows.into_iter().map(|r| GetCategoryStatsRow::from_row(&r)))
 }

--- a/examples/custom_type/src/queries.rs
+++ b/examples/custom_type/src/queries.rs
@@ -21,19 +21,22 @@ pub struct GetBoolsRow {
     pub col_bool_array_1: Option<Vec<bool>>,
     pub col_bool_array_2: Option<Vec<Vec<bool>>>,
 }
+impl GetBoolsRow {
+    pub(crate) fn from_row(row: &tokio_postgres::Row) -> Result<Self, tokio_postgres::Error> {
+        Ok(GetBoolsRow {
+            col_bool: row.try_get(0)?,
+            col_bool_alias: row.try_get(1)?,
+            col_bool_array_1: row.try_get(2)?,
+            col_bool_array_2: row.try_get(3)?,
+        })
+    }
+}
 pub async fn get_bools(
     client: &impl tokio_postgres::GenericClient,
 ) -> Result<impl Iterator<Item = Result<GetBoolsRow, tokio_postgres::Error>>, tokio_postgres::Error>
 {
     let rows = client.query(GET_BOOLS, &[]).await?;
-    Ok(rows.into_iter().map(|r| {
-        Ok(GetBoolsRow {
-            col_bool: r.try_get(0)?,
-            col_bool_alias: r.try_get(1)?,
-            col_bool_array_1: r.try_get(2)?,
-            col_bool_array_2: r.try_get(3)?,
-        })
-    }))
+    Ok(rows.into_iter().map(|r| GetBoolsRow::from_row(&r)))
 }
 pub const GET_NUMERICS: &str = r#"-- name: GetNumerics :many
 SELECT col_smallint, col_smallint_alias, col_integer, col_integer_alias, col_int_alias, col_serial, col_bigint, col_bigint_alias, col_decimal, col_decimal_alias, col_real, col_real_alias, col_double_precision, col_double_precision_alias, col_money
@@ -56,6 +59,27 @@ pub struct GetNumericsRow {
     pub col_double_precision_alias: Option<f64>,
     pub col_money: Option<postgres_money::Money>,
 }
+impl GetNumericsRow {
+    pub(crate) fn from_row(row: &tokio_postgres::Row) -> Result<Self, tokio_postgres::Error> {
+        Ok(GetNumericsRow {
+            col_smallint: row.try_get(0)?,
+            col_smallint_alias: row.try_get(1)?,
+            col_integer: row.try_get(2)?,
+            col_integer_alias: row.try_get(3)?,
+            col_int_alias: row.try_get(4)?,
+            col_serial: row.try_get(5)?,
+            col_bigint: row.try_get(6)?,
+            col_bigint_alias: row.try_get(7)?,
+            col_decimal: row.try_get(8)?,
+            col_decimal_alias: row.try_get(9)?,
+            col_real: row.try_get(10)?,
+            col_real_alias: row.try_get(11)?,
+            col_double_precision: row.try_get(12)?,
+            col_double_precision_alias: row.try_get(13)?,
+            col_money: row.try_get(14)?,
+        })
+    }
+}
 pub async fn get_numerics(
     client: &impl tokio_postgres::GenericClient,
 ) -> Result<
@@ -63,25 +87,7 @@ pub async fn get_numerics(
     tokio_postgres::Error,
 > {
     let rows = client.query(GET_NUMERICS, &[]).await?;
-    Ok(rows.into_iter().map(|r| {
-        Ok(GetNumericsRow {
-            col_smallint: r.try_get(0)?,
-            col_smallint_alias: r.try_get(1)?,
-            col_integer: r.try_get(2)?,
-            col_integer_alias: r.try_get(3)?,
-            col_int_alias: r.try_get(4)?,
-            col_serial: r.try_get(5)?,
-            col_bigint: r.try_get(6)?,
-            col_bigint_alias: r.try_get(7)?,
-            col_decimal: r.try_get(8)?,
-            col_decimal_alias: r.try_get(9)?,
-            col_real: r.try_get(10)?,
-            col_real_alias: r.try_get(11)?,
-            col_double_precision: r.try_get(12)?,
-            col_double_precision_alias: r.try_get(13)?,
-            col_money: r.try_get(14)?,
-        })
-    }))
+    Ok(rows.into_iter().map(|r| GetNumericsRow::from_row(&r)))
 }
 pub const GET_CHARACTERS: &str = r#"-- name: GetCharacters :many
 SELECT col_char, col_char_alias, col_varchar, col_varchar_alias, col_text
@@ -94,6 +100,17 @@ pub struct GetCharactersRow {
     pub col_varchar_alias: Option<String>,
     pub col_text: Option<String>,
 }
+impl GetCharactersRow {
+    pub(crate) fn from_row(row: &tokio_postgres::Row) -> Result<Self, tokio_postgres::Error> {
+        Ok(GetCharactersRow {
+            col_char: row.try_get(0)?,
+            col_char_alias: row.try_get(1)?,
+            col_varchar: row.try_get(2)?,
+            col_varchar_alias: row.try_get(3)?,
+            col_text: row.try_get(4)?,
+        })
+    }
+}
 pub async fn get_characters(
     client: &impl tokio_postgres::GenericClient,
 ) -> Result<
@@ -101,15 +118,7 @@ pub async fn get_characters(
     tokio_postgres::Error,
 > {
     let rows = client.query(GET_CHARACTERS, &[]).await?;
-    Ok(rows.into_iter().map(|r| {
-        Ok(GetCharactersRow {
-            col_char: r.try_get(0)?,
-            col_char_alias: r.try_get(1)?,
-            col_varchar: r.try_get(2)?,
-            col_varchar_alias: r.try_get(3)?,
-            col_text: r.try_get(4)?,
-        })
-    }))
+    Ok(rows.into_iter().map(|r| GetCharactersRow::from_row(&r)))
 }
 pub const GET_BINARIES: &str = r#"-- name: GetBinaries :many
 SELECT col_bytea
@@ -118,6 +127,13 @@ FROM BinaryTable"#;
 pub struct GetBinariesRow {
     pub col_bytea: Option<Vec<u8>>,
 }
+impl GetBinariesRow {
+    pub(crate) fn from_row(row: &tokio_postgres::Row) -> Result<Self, tokio_postgres::Error> {
+        Ok(GetBinariesRow {
+            col_bytea: row.try_get(0)?,
+        })
+    }
+}
 pub async fn get_binaries(
     client: &impl tokio_postgres::GenericClient,
 ) -> Result<
@@ -125,11 +141,7 @@ pub async fn get_binaries(
     tokio_postgres::Error,
 > {
     let rows = client.query(GET_BINARIES, &[]).await?;
-    Ok(rows.into_iter().map(|r| {
-        Ok(GetBinariesRow {
-            col_bytea: r.try_get(0)?,
-        })
-    }))
+    Ok(rows.into_iter().map(|r| GetBinariesRow::from_row(&r)))
 }
 pub const GET_CUSTOM_TYPE: &str = r#"-- name: GetCustomType :many
 SELECT voice_actor, character
@@ -139,6 +151,14 @@ pub struct GetCustomTypeRow {
     pub voice_actor: Option<crate::VoiceActor>,
     pub character: Option<SpongeBobCharacter>,
 }
+impl GetCustomTypeRow {
+    pub(crate) fn from_row(row: &tokio_postgres::Row) -> Result<Self, tokio_postgres::Error> {
+        Ok(GetCustomTypeRow {
+            voice_actor: row.try_get(0)?,
+            character: row.try_get(1)?,
+        })
+    }
+}
 pub async fn get_custom_type(
     client: &impl tokio_postgres::GenericClient,
 ) -> Result<
@@ -146,12 +166,7 @@ pub async fn get_custom_type(
     tokio_postgres::Error,
 > {
     let rows = client.query(GET_CUSTOM_TYPE, &[]).await?;
-    Ok(rows.into_iter().map(|r| {
-        Ok(GetCustomTypeRow {
-            voice_actor: r.try_get(0)?,
-            character: r.try_get(1)?,
-        })
-    }))
+    Ok(rows.into_iter().map(|r| GetCustomTypeRow::from_row(&r)))
 }
 pub const CREATE_VOICE_ACTOR: &str = r#"-- name: CreateVoiceActor :one
 INSERT INTO SpongeBobVoiceActor
@@ -163,20 +178,63 @@ pub struct CreateVoiceActorRow {
     pub voice_actor: Option<crate::VoiceActor>,
     pub character: Option<SpongeBobCharacter>,
 }
+impl CreateVoiceActorRow {
+    pub(crate) fn from_row(row: &tokio_postgres::Row) -> Result<Self, tokio_postgres::Error> {
+        Ok(CreateVoiceActorRow {
+            voice_actor: row.try_get(0)?,
+            character: row.try_get(1)?,
+        })
+    }
+}
 pub async fn create_voice_actor(
     client: &impl tokio_postgres::GenericClient,
     voice_actor: Option<&crate::VoiceActor>,
     character: Option<SpongeBobCharacter>,
 ) -> Result<Option<CreateVoiceActorRow>, tokio_postgres::Error> {
-    let row = client
-        .query_opt(CREATE_VOICE_ACTOR, &[&voice_actor, &character])
-        .await?;
-    let v = match row {
-        Some(v) => CreateVoiceActorRow {
-            voice_actor: v.try_get(0)?,
-            character: v.try_get(1)?,
-        },
-        None => return Ok(None),
+    let query_struct = CreateVoiceActor {
+        voice_actor: voice_actor.map(std::borrow::Cow::Borrowed),
+        character: character,
     };
-    Ok(Some(v))
+    query_struct.query_opt(client).await
+}
+#[derive(Debug)]
+pub struct CreateVoiceActor<'a> {
+    pub voice_actor: Option<std::borrow::Cow<'a, crate::VoiceActor>>,
+    pub character: Option<SpongeBobCharacter>,
+}
+impl<'a> CreateVoiceActor<'a> {
+    pub const QUERY: &'static str = r#"-- name: CreateVoiceActor :one
+INSERT INTO SpongeBobVoiceActor
+(voice_actor,character)
+VALUES ($1, $2)
+RETURNING voice_actor, character"#;
+}
+impl<'a> CreateVoiceActor<'a> {
+    pub async fn query_one(
+        &self,
+        client: &impl tokio_postgres::GenericClient,
+    ) -> Result<CreateVoiceActorRow, tokio_postgres::Error> {
+        let row = client
+            .query_one(
+                Self::QUERY,
+                &[&self.voice_actor.as_deref(), &self.character],
+            )
+            .await?;
+        CreateVoiceActorRow::from_row(&row)
+    }
+    pub async fn query_opt(
+        &self,
+        client: &impl tokio_postgres::GenericClient,
+    ) -> Result<Option<CreateVoiceActorRow>, tokio_postgres::Error> {
+        let row = client
+            .query_opt(
+                Self::QUERY,
+                &[&self.voice_actor.as_deref(), &self.character],
+            )
+            .await?;
+        match row {
+            Some(ref row) => Ok(Some(CreateVoiceActorRow::from_row(row)?)),
+            None => Ok(None),
+        }
+    }
 }

--- a/src/db_support/column_types.rs
+++ b/src/db_support/column_types.rs
@@ -103,7 +103,7 @@ impl PgColumnRef {
     }
 
     /// Check if the type is copy-cheap (should be passed by value rather than reference)
-    fn is_copy_cheap_type(&self, type_map: &impl crate::user_type::TypeMap) -> bool {
+    pub(crate) fn is_copy_cheap_type(&self, type_map: &impl crate::user_type::TypeMap) -> bool {
         // Only consider non-array types for copy-cheap optimization
         if self.inner.array_dim.is_some() {
             return false;

--- a/src/db_support/crate_types.rs
+++ b/src/db_support/crate_types.rs
@@ -82,4 +82,20 @@ impl DbCrate {
             }
         }
     }
+
+    /// Returns the row type tokens for the specific database crate
+    pub(crate) fn row_ident(&self) -> TokenStream {
+        match self {
+            DbCrate::TokioPostgres => {
+                quote! {tokio_postgres::Row}
+            }
+            DbCrate::Postgres => {
+                quote! {postgres::Row}
+            }
+            DbCrate::DeadPoolPostgres => {
+                // deadpool_postgres use tokio_postgres::Row
+                quote! {deadpool_postgres::tokio_postgres::Row}
+            }
+        }
+    }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,8 +1,10 @@
 use crate::db_support::DbCrate;
 use crate::plugin;
+use crate::rust_gen::builder_gen::PostgresBuilderGen;
 use crate::rust_gen::const_gen::PostgresConstQuery;
 use crate::rust_gen::func_gen::PostgresFunc;
 use crate::rust_gen::param_gen::PgParams;
+use crate::rust_gen::struct_api_gen::PostgresStructApi;
 use crate::rust_gen::struct_gen::PgStruct;
 use crate::sqlc::QueryAnnotation;
 use crate::user_type::TypeMap;
@@ -15,6 +17,8 @@ pub(crate) struct PostgresQuery {
     returning_row: PgStruct,
     query_params: PgParams,
     query_func: PostgresFunc,
+    struct_api: PostgresStructApi,
+    builder_gen: PostgresBuilderGen,
 }
 
 impl PostgresQuery {
@@ -26,15 +30,19 @@ impl PostgresQuery {
         let query_type = query.cmd.parse::<QueryAnnotation>().unwrap();
 
         let query_const = PostgresConstQuery::new(query, &query_type);
-        let returning_row = PgStruct::new(query, pg_map)?;
+        let returning_row = PgStruct::new(query, pg_map, db_crate)?;
         let query_params = PgParams::new(query, pg_map)?;
         let query_func = PostgresFunc::new(query, query_type.clone(), db_crate);
+        let struct_api = PostgresStructApi::new(query, query_type.clone(), db_crate);
+        let builder_gen = PostgresBuilderGen::new(crate::utils::rust_value_ident(&query.name));
         Ok(Self {
             query_type,
             query_const,
             returning_row,
             query_params,
             query_func,
+            struct_api,
+            builder_gen,
         })
     }
 
@@ -49,15 +57,42 @@ impl PostgresQuery {
             query_params,
             query_type,
             query_func,
+            struct_api,
             ..
         } = self;
-        let query_tt = query_const.to_tokens()?;
+        // Generate struct-based API only if there are parameters
+        let struct_api_tokens = if !query_params.params.is_empty() {
+            let query_struct =
+                struct_api.generate_query_struct(query_const, query_params, type_map);
+            let execution_methods = struct_api.generate_execution_methods(
+                query_const,
+                returning_row,
+                query_params,
+                type_map,
+            );
+            // Temporarily disable builder generation to test basic struct API
+            // let builder_pattern = builder_gen.generate_builder(query_params, type_map);
+
+            quote! {
+                #query_struct
+                #execution_methods
+                // #builder_pattern
+            }
+        } else {
+            quote! {}
+        };
+
         let query_func = query_func.generate(query_const, returning_row, query_params, type_map)?;
+
+        // Always generate standalone query constant for backward compatibility
+        let query_tt = query_const.to_tokens()?;
+
         let tokens = match query_type {
             QueryAnnotation::Exec => {
                 quote! {
                     #query_tt
                     #query_func
+                    #struct_api_tokens
                 }
             }
             _ => {
@@ -66,6 +101,7 @@ impl PostgresQuery {
                     #row_derive
                     #returning_row
                     #query_func
+                    #struct_api_tokens
                 }
             }
         };

--- a/src/rust_gen/builder_gen.rs
+++ b/src/rust_gen/builder_gen.rs
@@ -1,0 +1,437 @@
+use crate::rust_gen::param_gen::PgParams;
+use crate::user_type::TypeMap;
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::Ident;
+
+/// Type-state builder pattern generator for zero-cost query construction
+#[derive(Debug, Clone)]
+pub(crate) struct PostgresBuilderGen {
+    query_name: String,
+}
+
+impl PostgresBuilderGen {
+    pub(crate) fn new(query_name: String) -> Self {
+        Self { query_name }
+    }
+
+    /// Generate the complete type-state builder pattern
+    pub(crate) fn generate_builder(
+        &self,
+        query_params: &PgParams,
+        type_map: &impl TypeMap,
+    ) -> TokenStream {
+        if query_params.params.is_empty() {
+            return quote! {};
+        }
+
+        let struct_ident = self.query_struct_ident();
+        let builder_ident = self.builder_struct_ident();
+        let has_lifetime = self.needs_lifetime(query_params, type_map);
+
+        let builder_struct = self.generate_builder_struct(query_params, type_map);
+        let builder_methods = self.generate_builder_methods(query_params, type_map);
+        let build_method = self.generate_build_method(query_params, type_map);
+        let constructor_method = self.generate_constructor_method(query_params, type_map);
+
+        quote! {
+            #builder_struct
+            #constructor_method
+            #builder_methods
+            #build_method
+        }
+    }
+
+    /// Generate the builder struct with type-state parameters
+    fn generate_builder_struct(
+        &self,
+        query_params: &PgParams,
+        type_map: &impl TypeMap,
+    ) -> TokenStream {
+        let builder_ident = self.builder_struct_ident();
+        let param_count = query_params.params.len();
+        let has_lifetime = self.needs_lifetime(query_params, type_map);
+
+        // Generate initial type state (all (), meaning unset)
+        let initial_fields_type = self.generate_tuple_type(&vec![quote! { () }; param_count]);
+
+        let lifetime_param = if has_lifetime {
+            quote! { <'a, Fields = #initial_fields_type> }
+        } else {
+            quote! { <Fields = #initial_fields_type> }
+        };
+
+        let phantom_type = if has_lifetime {
+            quote! { std::marker::PhantomData<&'a ()> }
+        } else {
+            quote! { std::marker::PhantomData<()> }
+        };
+
+        quote! {
+            #[derive(Debug)]
+            pub struct #builder_ident #lifetime_param {
+                fields: Fields,
+                phantom: #phantom_type,
+            }
+        }
+    }
+
+    /// Generate builder constructor method on the main struct
+    fn generate_constructor_method(
+        &self,
+        query_params: &PgParams,
+        type_map: &impl TypeMap,
+    ) -> TokenStream {
+        let struct_ident = self.query_struct_ident();
+        let builder_ident = self.builder_struct_ident();
+        let param_count = query_params.params.len();
+        let has_lifetime = self.needs_lifetime(query_params, type_map);
+
+        // Generate initial tuple of () values
+        let initial_tuple = self.generate_tuple_value(&vec![quote! { () }; param_count]);
+        let initial_fields_type = self.generate_tuple_type(&vec![quote! { () }; param_count]);
+
+        let lifetime_param = if has_lifetime {
+            quote! { <'a> }
+        } else {
+            quote! {}
+        };
+
+        let return_type = if has_lifetime {
+            quote! { #builder_ident<'a, #initial_fields_type> }
+        } else {
+            quote! { #builder_ident<#initial_fields_type> }
+        };
+
+        quote! {
+            impl #lifetime_param #struct_ident #lifetime_param {
+                pub fn builder() -> #return_type {
+                    #builder_ident {
+                        fields: #initial_tuple,
+                        phantom: std::marker::PhantomData,
+                    }
+                }
+            }
+        }
+    }
+
+    /// Generate setter methods for each parameter
+    fn generate_builder_methods(
+        &self,
+        query_params: &PgParams,
+        type_map: &impl TypeMap,
+    ) -> TokenStream {
+        let builder_ident = self.builder_struct_ident();
+        let param_count = query_params.params.len();
+        let has_lifetime = self.needs_lifetime(query_params, type_map);
+
+        let mut methods = quote! {};
+
+        for (param_index, param) in query_params.params.iter().enumerate() {
+            let method_ident = Ident::new(&param.inner.name, proc_macro2::Span::call_site());
+
+            // Generate type state for this specific parameter position
+            let before_types = self.generate_generic_types_for_position(
+                param_count,
+                param_index,
+                false,
+                param,
+                type_map,
+            );
+            let after_types = self.generate_generic_types_for_position(
+                param_count,
+                param_index,
+                true,
+                param,
+                type_map,
+            );
+
+            // Determine parameter type based on copy_types optimization
+            let param_type = if param.is_copy_cheap_type(type_map) {
+                let rs_type = &param.inner.rs_type;
+                if param.inner.is_nullable {
+                    quote! { Option<#rs_type> }
+                } else {
+                    quote! { #rs_type }
+                }
+            } else {
+                let base_type = param.wrap_type();
+                if param.inner.is_nullable {
+                    quote! { Option<T> }
+                } else {
+                    quote! { T }
+                }
+            };
+
+            // Generate where clause for Into<Cow> for non-copy types
+            let (where_clause, value_conversion) = if param.is_copy_cheap_type(type_map) {
+                (quote! {}, quote! { #method_ident })
+            } else {
+                let base_type = param.wrap_type();
+                if param.inner.is_nullable {
+                    (
+                        quote! { where T: Into<Option<std::borrow::Cow<'a, #base_type>>> },
+                        quote! { #method_ident.into() },
+                    )
+                } else {
+                    (
+                        quote! { where T: Into<std::borrow::Cow<'a, #base_type>> },
+                        quote! { #method_ident.into() },
+                    )
+                }
+            };
+
+            // Generate destructuring pattern for current state
+            let destructure_pattern = self.generate_destructure_pattern(param_count, param_index);
+            let reconstruct_pattern =
+                self.generate_reconstruct_pattern(param_count, param_index, &param.inner.name);
+
+            let before_fields_type = self.generate_tuple_type(&before_types);
+            let after_fields_type = self.generate_tuple_type(&after_types);
+
+            let lifetime_bounds = if has_lifetime {
+                quote! { <'a, #before_fields_type> }
+            } else {
+                quote! { <#before_fields_type> }
+            };
+
+            let return_type = if has_lifetime {
+                quote! { #builder_ident<'a, #after_fields_type> }
+            } else {
+                quote! { #builder_ident<#after_fields_type> }
+            };
+
+            let method = if param.is_copy_cheap_type(type_map) {
+                quote! {
+                    impl #lifetime_bounds #builder_ident #lifetime_bounds {
+                        pub fn #method_ident(self, #method_ident: #param_type) -> #return_type {
+                            let #destructure_pattern = self.fields;
+                            #builder_ident {
+                                fields: #reconstruct_pattern,
+                                phantom: std::marker::PhantomData,
+                            }
+                        }
+                    }
+                }
+            } else {
+                quote! {
+                    impl #lifetime_bounds #builder_ident #lifetime_bounds {
+                        pub fn #method_ident<T>(self, #method_ident: T) -> #return_type
+                        #where_clause
+                        {
+                            let #destructure_pattern = self.fields;
+                            #builder_ident {
+                                fields: #reconstruct_pattern,
+                                phantom: std::marker::PhantomData,
+                            }
+                        }
+                    }
+                }
+            };
+
+            methods.extend(method);
+        }
+
+        methods
+    }
+
+    /// Generate the build method (only available when all fields are set)
+    fn generate_build_method(
+        &self,
+        query_params: &PgParams,
+        type_map: &impl TypeMap,
+    ) -> TokenStream {
+        let struct_ident = self.query_struct_ident();
+        let builder_ident = self.builder_struct_ident();
+        let param_count = query_params.params.len();
+        let has_lifetime = self.needs_lifetime(query_params, type_map);
+
+        // Generate complete type state (all fields set)
+        let complete_types: Vec<TokenStream> = query_params
+            .params
+            .iter()
+            .map(|param| {
+                if param.is_copy_cheap_type(type_map) {
+                    let rs_type = &param.inner.rs_type;
+                    if param.inner.is_nullable {
+                        quote! { Option<#rs_type> }
+                    } else {
+                        quote! { #rs_type }
+                    }
+                } else {
+                    let base_type = param.wrap_type();
+                    if param.inner.is_nullable {
+                        quote! { Option<std::borrow::Cow<'a, #base_type>> }
+                    } else {
+                        quote! { std::borrow::Cow<'a, #base_type> }
+                    }
+                }
+            })
+            .collect();
+
+        let complete_fields_type = self.generate_tuple_type(&complete_types);
+
+        // Generate destructuring for all fields
+        let field_names: Vec<Ident> = query_params
+            .params
+            .iter()
+            .map(|param| Ident::new(&param.inner.name, proc_macro2::Span::call_site()))
+            .collect();
+
+        let destructure_all = if param_count == 1 {
+            let field = &field_names[0];
+            quote! { #field }
+        } else {
+            quote! { (#(#field_names),*) }
+        };
+
+        let lifetime_bounds = if has_lifetime {
+            quote! { <'a> }
+        } else {
+            quote! {}
+        };
+
+        let builder_type = if has_lifetime {
+            quote! { #builder_ident<'a, #complete_fields_type> }
+        } else {
+            quote! { #builder_ident<#complete_fields_type> }
+        };
+
+        let return_type = if has_lifetime {
+            quote! { #struct_ident<'a> }
+        } else {
+            quote! { #struct_ident }
+        };
+
+        quote! {
+            impl #lifetime_bounds #builder_type {
+                pub fn build(self) -> #return_type {
+                    let #destructure_all = self.fields;
+                    #struct_ident {
+                        #(#field_names),*
+                    }
+                }
+            }
+        }
+    }
+
+    fn query_struct_ident(&self) -> Ident {
+        Ident::new(&self.query_name, proc_macro2::Span::call_site())
+    }
+
+    fn builder_struct_ident(&self) -> Ident {
+        let builder_name = format!("{}Builder", self.query_name);
+        Ident::new(&builder_name, proc_macro2::Span::call_site())
+    }
+
+    fn needs_lifetime(&self, query_params: &PgParams, type_map: &impl TypeMap) -> bool {
+        query_params
+            .params
+            .iter()
+            .any(|param| !param.is_copy_cheap_type(type_map))
+    }
+
+    fn generate_tuple_type(&self, types: &[TokenStream]) -> TokenStream {
+        match types.len() {
+            0 => quote! { () },
+            1 => types[0].clone(),
+            _ => quote! { (#(#types),*) },
+        }
+    }
+
+    fn generate_tuple_value(&self, values: &[TokenStream]) -> TokenStream {
+        match values.len() {
+            0 => quote! { () },
+            1 => values[0].clone(),
+            _ => quote! { (#(#values),*) },
+        }
+    }
+
+    fn generate_generic_types_for_position(
+        &self,
+        total_count: usize,
+        position: usize,
+        is_set: bool,
+        param: &crate::db_support::PgColumnRef,
+        type_map: &impl TypeMap,
+    ) -> Vec<TokenStream> {
+        (0..total_count)
+            .map(|i| {
+                if i == position && is_set {
+                    // This position is being set - use the actual parameter type
+                    if param.is_copy_cheap_type(type_map) {
+                        let rs_type = &param.inner.rs_type;
+                        if param.inner.is_nullable {
+                            quote! { Option<#rs_type> }
+                        } else {
+                            quote! { #rs_type }
+                        }
+                    } else {
+                        let base_type = param.wrap_type();
+                        if param.inner.is_nullable {
+                            quote! { Option<std::borrow::Cow<'a, #base_type>> }
+                        } else {
+                            quote! { std::borrow::Cow<'a, #base_type> }
+                        }
+                    }
+                } else if i == position {
+                    // This position is unset
+                    quote! { () }
+                } else {
+                    // Other positions use generic type variables
+                    let var_name = format!("V{}", i);
+                    let ident = Ident::new(&var_name, proc_macro2::Span::call_site());
+                    quote! { #ident }
+                }
+            })
+            .collect()
+    }
+
+    fn generate_destructure_pattern(
+        &self,
+        total_count: usize,
+        setting_position: usize,
+    ) -> TokenStream {
+        let vars: Vec<TokenStream> = (0..total_count)
+            .map(|i| {
+                if i == setting_position {
+                    quote! { () }
+                } else {
+                    let var_name = format!("v{}", i);
+                    let ident = Ident::new(&var_name, proc_macro2::Span::call_site());
+                    quote! { #ident }
+                }
+            })
+            .collect();
+
+        match vars.len() {
+            1 => vars[0].clone(),
+            _ => quote! { (#(#vars),*) },
+        }
+    }
+
+    fn generate_reconstruct_pattern(
+        &self,
+        total_count: usize,
+        setting_position: usize,
+        param_name: &str,
+    ) -> TokenStream {
+        let vars: Vec<TokenStream> = (0..total_count)
+            .map(|i| {
+                if i == setting_position {
+                    let ident = Ident::new(param_name, proc_macro2::Span::call_site());
+                    quote! { #ident }
+                } else {
+                    let var_name = format!("v{}", i);
+                    let ident = Ident::new(&var_name, proc_macro2::Span::call_site());
+                    quote! { #ident }
+                }
+            })
+            .collect();
+
+        match vars.len() {
+            1 => vars[0].clone(),
+            _ => quote! { (#(#vars),*) },
+        }
+    }
+}

--- a/src/rust_gen/const_gen.rs
+++ b/src/rust_gen/const_gen.rs
@@ -52,4 +52,14 @@ impl PostgresConstQuery {
             pub const #ident: &str = #raw_literal;
         })
     }
+
+    pub(crate) fn as_struct_const(&self) -> crate::Result<proc_macro2::TokenStream> {
+        let raw_str = format!("r#\"{}\"#", self.sql_str());
+        let raw_literal = raw_str.parse::<proc_macro2::TokenStream>().map_err(|_| {
+            crate::Error::any_error(format!("Failed to parse raw literal({})", raw_str))
+        })?;
+        Ok(quote! {
+            pub const QUERY: &'static str = #raw_literal;
+        })
+    }
 }

--- a/src/rust_gen/func_gen.rs
+++ b/src/rust_gen/func_gen.rs
@@ -75,27 +75,40 @@ impl PostgresFunc {
         type_map: &impl crate::user_type::TypeMap,
     ) -> proc_macro2::TokenStream {
         let func_def = self.func_def(query_params, type_map);
-        let await_def = self.db_crate.await_ident();
-
         let error_ident = self.db_crate.error_ident();
-
-        let query_ident = query_const.ident();
         let returning_ident = returning_row.ident();
-        let params = query_params.to_stmt_params();
 
-        let row_ident = Ident::new("row", Span::call_site());
-        let val_ident = Ident::new("v", Span::call_site());
-        let from_expr = returning_row.to_from_row_expr(&val_ident);
+        // If there are parameters, use the struct API internally
+        if !query_params.params.is_empty() {
+            let struct_ident = Ident::new(
+                &crate::utils::rust_value_ident(&self.query_name),
+                Span::call_site(),
+            );
+            let field_assignments = self.generate_struct_field_assignments(query_params, type_map);
 
-        quote! {
-            #func_def -> Result<Option<#returning_ident>,#error_ident> {
-                let #row_ident = client.query_opt(#query_ident,#params)#await_def?;
-                let #val_ident = match #row_ident {
-                    Some(#val_ident) => #from_expr,
-                    None => return Ok(None),
-                };
+            quote! {
+                #func_def -> Result<Option<#returning_ident>,#error_ident> {
+                    let query_struct = #struct_ident {
+                        #field_assignments
+                    };
+                    query_struct.query_opt(client).await
+                }
+            }
+        } else {
+            // For queries without parameters, keep the original implementation
+            let await_def = self.db_crate.await_ident();
+            let query_ident = query_const.ident();
+            let params = query_params.to_stmt_params();
+            let row_ident = Ident::new("row", Span::call_site());
 
-                Ok(Some(#val_ident))
+            quote! {
+                #func_def -> Result<Option<#returning_ident>,#error_ident> {
+                    let #row_ident = client.query_opt(#query_ident,#params)#await_def?;
+                    match #row_ident {
+                        Some(ref #row_ident) => Ok(Some(#returning_ident::from_row(#row_ident)?)),
+                        None => Ok(None),
+                    }
+                }
             }
         }
     }
@@ -118,14 +131,49 @@ impl PostgresFunc {
 
         let rows_ident = Ident::new("rows", Span::call_site());
         let row_ident = Ident::new("r", Span::call_site());
-        let from_expr = returning_row.to_from_row_expr(&row_ident);
 
         quote! {
             #func_def -> Result<impl Iterator<Item = Result<#returning_ident,#error_ident>>,#error_ident> {
                 let #rows_ident = client.query(#query_ident,#params)#await_def?;
-                Ok(#rows_ident.into_iter().map(|#row_ident|Ok(#from_expr)))
+                Ok(#rows_ident.into_iter().map(|#row_ident| #returning_ident::from_row(&#row_ident)))
             }
         }
+    }
+
+    fn generate_struct_field_assignments(
+        &self,
+        query_params: &PgParams,
+        type_map: &impl crate::user_type::TypeMap,
+    ) -> proc_macro2::TokenStream {
+        let mut assignments = quote! {};
+
+        for param in query_params.params.iter() {
+            let field_name = &param.inner.name;
+            let field_ident = Ident::new(field_name, Span::call_site());
+            let param_ident = Ident::new(field_name, Span::call_site());
+
+            if param.is_copy_cheap_type(type_map) {
+                // Copy-cheap types: direct assignment
+                assignments.extend(quote! {
+                    #field_ident: #param_ident,
+                });
+            } else {
+                // Non-copy types: handle Option<T> vs T appropriately
+                if !param.inner.is_nullable {
+                    // Non-optional: T -> Cow::Borrowed(T)
+                    assignments.extend(quote! {
+                        #field_ident: std::borrow::Cow::Borrowed(#param_ident),
+                    });
+                } else {
+                    // Optional: Option<T> -> Option<Cow<'a, T>>
+                    assignments.extend(quote! {
+                        #field_ident: #param_ident.map(std::borrow::Cow::Borrowed),
+                    });
+                }
+            }
+        }
+
+        assignments
     }
 
     pub(crate) fn generate(

--- a/src/rust_gen/mod.rs
+++ b/src/rust_gen/mod.rs
@@ -1,5 +1,7 @@
+pub mod builder_gen;
 pub mod const_gen;
 pub mod func_gen;
 pub mod naming;
 pub mod param_gen;
+pub mod struct_api_gen;
 pub mod struct_gen;

--- a/src/rust_gen/struct_api_gen.rs
+++ b/src/rust_gen/struct_api_gen.rs
@@ -1,0 +1,228 @@
+use crate::db_support::DbCrate;
+use crate::rust_gen::naming::RustSelfIdent;
+use crate::rust_gen::param_gen::PgParams;
+use crate::rust_gen::struct_gen::PgStruct;
+use crate::sqlc::QueryAnnotation;
+use crate::user_type::TypeMap;
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// Struct-based API generator for type-safe query building
+#[derive(Debug, Clone)]
+pub(crate) struct PostgresStructApi {
+    query_name: String,
+    annotation: QueryAnnotation,
+    db_crate: DbCrate,
+}
+
+impl PostgresStructApi {
+    pub(crate) fn new(
+        query: &crate::plugin::Query,
+        annotation: QueryAnnotation,
+        db_crate: DbCrate,
+    ) -> Self {
+        let query_name = crate::utils::rust_value_ident(&query.name);
+        Self {
+            query_name,
+            annotation,
+            db_crate,
+        }
+    }
+
+    /// Generate the main query struct that holds parameters
+    pub(crate) fn generate_query_struct(
+        &self,
+        query_const: &crate::rust_gen::const_gen::PostgresConstQuery,
+        query_params: &PgParams,
+        type_map: &impl TypeMap,
+    ) -> TokenStream {
+        if query_params.params.is_empty() {
+            return quote! {};
+        }
+
+        let struct_ident = self.query_struct_ident();
+        let mut field_tokens = quote! {};
+        let has_lifetime = self.needs_lifetime(query_params, type_map);
+        let query_const_tokens = query_const.as_struct_const().unwrap_or_default();
+
+        // Generate struct fields with optimized types
+        for param in &query_params.params {
+            let field_name = &param.inner.name;
+            let field_ident = syn::Ident::new(field_name, proc_macro2::Span::call_site());
+
+            if param.is_copy_cheap_type(type_map) {
+                // Copy-cheap types: pass by value
+                let rs_type = &param.inner.rs_type;
+                if param.inner.is_nullable {
+                    field_tokens.extend(quote! {
+                        pub #field_ident: Option<#rs_type>,
+                    });
+                } else {
+                    field_tokens.extend(quote! {
+                        pub #field_ident: #rs_type,
+                    });
+                }
+            } else {
+                // Non-copy types: use Cow for optimization
+                let base_type = param.wrap_type();
+                if param.inner.is_nullable {
+                    field_tokens.extend(quote! {
+                        pub #field_ident: Option<std::borrow::Cow<'a, #base_type>>,
+                    });
+                } else {
+                    field_tokens.extend(quote! {
+                        pub #field_ident: std::borrow::Cow<'a, #base_type>,
+                    });
+                }
+            }
+        }
+
+        let lifetime_param = if has_lifetime {
+            quote! { <'a> }
+        } else {
+            quote! {}
+        };
+
+        quote! {
+            #[derive(Debug)]
+            pub struct #struct_ident #lifetime_param {
+                #field_tokens
+            }
+
+            impl #lifetime_param #struct_ident #lifetime_param {
+                #query_const_tokens
+            }
+        }
+    }
+
+    /// Generate execution methods based on QueryAnnotation
+    pub(crate) fn generate_execution_methods(
+        &self,
+        query_const: &crate::rust_gen::const_gen::PostgresConstQuery,
+        returning_row: &PgStruct,
+        query_params: &PgParams,
+        type_map: &impl TypeMap,
+    ) -> TokenStream {
+        if query_params.params.is_empty() {
+            return quote! {};
+        }
+
+        let struct_ident = self.query_struct_ident();
+        let has_lifetime = self.needs_lifetime(query_params, type_map);
+        let lifetime_param = if has_lifetime {
+            quote! { <'a> }
+        } else {
+            quote! {}
+        };
+
+        let client_ident = self.db_crate.client_ident();
+        let error_ident = self.db_crate.error_ident();
+        let await_def = self.db_crate.await_ident();
+        let query_ident = query_const.ident();
+
+        // Generate parameter passing for SQL execution
+        let params = self.generate_stmt_params(query_params, type_map);
+
+        match self.annotation {
+            QueryAnnotation::One => {
+                let returning_ident = returning_row.ident();
+                let row_ident = syn::Ident::new("row", proc_macro2::Span::call_site());
+
+                quote! {
+                    impl #lifetime_param #struct_ident #lifetime_param {
+                        pub async fn query_one(&self, client: #client_ident) -> Result<#returning_ident, #error_ident> {
+                            let #row_ident = client.query_one(Self::QUERY, #params)#await_def?;
+                            #returning_ident::from_row(&#row_ident)
+                        }
+
+                        pub async fn query_opt(&self, client: #client_ident) -> Result<Option<#returning_ident>, #error_ident> {
+                            let #row_ident = client.query_opt(Self::QUERY, #params)#await_def?;
+                            match #row_ident {
+                                Some(ref #row_ident) => Ok(Some(#returning_ident::from_row(#row_ident)?)),
+                                None => Ok(None),
+                            }
+                        }
+                    }
+                }
+            }
+            QueryAnnotation::Many => {
+                let returning_ident = returning_row.ident();
+                let rows_ident = syn::Ident::new("rows", proc_macro2::Span::call_site());
+                let row_ident = syn::Ident::new("r", proc_macro2::Span::call_site());
+
+                quote! {
+                    impl #lifetime_param #struct_ident #lifetime_param {
+                        pub async fn query_many(&self, client: #client_ident) -> Result<Vec<#returning_ident>, #error_ident> {
+                            let #rows_ident = client.query(Self::QUERY, #params)#await_def?;
+                            #rows_ident.into_iter().map(|#row_ident| #returning_ident::from_row(&#row_ident)).collect()
+                        }
+
+                        pub async fn query_raw(&self, client: #client_ident) -> Result<impl Iterator<Item = Result<#returning_ident, #error_ident>>, #error_ident> {
+                            let #rows_ident = client.query(Self::QUERY, #params)#await_def?;
+                            Ok(#rows_ident.into_iter().map(|#row_ident| #returning_ident::from_row(&#row_ident)))
+                        }
+                    }
+                }
+            }
+            QueryAnnotation::Exec => {
+                quote! {
+                    impl #lifetime_param #struct_ident #lifetime_param {
+                        pub async fn execute(&self, client: #client_ident) -> Result<u64, #error_ident> {
+                            client.execute(Self::QUERY, #params)#await_def
+                        }
+                    }
+                }
+            }
+            _ => {
+                // For unsupported annotations, return empty implementation
+                quote! {}
+            }
+        }
+    }
+
+    fn query_struct_ident(&self) -> syn::Ident {
+        syn::Ident::new(&self.query_name, proc_macro2::Span::call_site())
+    }
+
+    fn needs_lifetime(&self, query_params: &PgParams, type_map: &impl TypeMap) -> bool {
+        query_params
+            .params
+            .iter()
+            .any(|param| !param.is_copy_cheap_type(type_map))
+    }
+
+    fn generate_stmt_params(
+        &self,
+        query_params: &PgParams,
+        type_map: &impl TypeMap,
+    ) -> TokenStream {
+        let mut param_tokens = quote! {};
+
+        for param in &query_params.params {
+            let field_name = &param.inner.name;
+            let field_ident = syn::Ident::new(field_name, proc_macro2::Span::call_site());
+
+            if param.is_copy_cheap_type(type_map) {
+                // Copy-cheap types: pass by reference for SQL execution
+                param_tokens.extend(quote! { &self.#field_ident, });
+            } else {
+                // Non-copy types: handle Cow and Option<Cow> appropriately
+                if !param.inner.is_nullable {
+                    // Non-optional: Cow<'a, T> -> .as_ref() returns &T, need & for ToSql
+                    param_tokens.extend(quote! { &self.#field_ident.as_ref(), });
+                } else {
+                    // Optional: Option<Cow<'a, T>> -> .as_deref() returns Option<&T>, need & for ToSql
+                    param_tokens.extend(quote! { &self.#field_ident.as_deref(), });
+                }
+            }
+        }
+
+        quote! { &[#param_tokens] }
+    }
+}
+
+impl RustSelfIdent for PostgresStructApi {
+    fn ident_str(&self) -> String {
+        self.query_name.clone()
+    }
+}

--- a/src/rust_gen/struct_gen.rs
+++ b/src/rust_gen/struct_gen.rs
@@ -13,10 +13,15 @@ use syn::Ident;
 pub(crate) struct PgStruct {
     pub(crate) name: String,
     pub(crate) columns: Vec<PgColumn>,
+    pub(crate) db_crate: crate::db_support::DbCrate,
 }
 
 impl PgStruct {
-    pub(crate) fn new(query: &plugin::Query, pg_map: &impl TypeMap) -> crate::Result<Self> {
+    pub(crate) fn new(
+        query: &plugin::Query,
+        pg_map: &impl TypeMap,
+        db_crate: crate::db_support::DbCrate,
+    ) -> crate::Result<Self> {
         let is_single_table_identifier = has_single_table_identifier(query);
 
         // Generate unique field names to avoid conflicts
@@ -50,7 +55,11 @@ impl PgStruct {
 
         let name = utils::rust_value_ident(&query.name);
         let name = format!("{}Row", name);
-        Ok(Self { name, columns })
+        Ok(Self {
+            name,
+            columns,
+            db_crate,
+        })
     }
 
     pub(crate) fn to_from_row_expr(&self, var_ident: &Ident) -> proc_macro2::TokenStream {
@@ -87,10 +96,42 @@ impl ToTokens for PgStruct {
 
         let ident = self.ident();
         let columns = &self.columns;
+        let from_row_method = self.generate_from_row_method();
+
         tokens.extend(quote! {
             pub struct #ident {
                 #(#columns),*
             }
+
+            impl #ident {
+                #from_row_method
+            }
         });
+    }
+}
+
+impl PgStruct {
+    /// Generate a private from_row method to reduce code duplication
+    fn generate_from_row_method(&self) -> proc_macro2::TokenStream {
+        let mut field_assignments = quote! {};
+        for (idx, c) in self.columns.iter().enumerate() {
+            let field_ident = Ident::new(&c.name, Span::call_site());
+            let literal = Literal::usize_unsuffixed(idx);
+            field_assignments.extend(quote! {
+                #field_ident: row.try_get(#literal)?,
+            });
+        }
+
+        let ident = self.ident();
+        let row_type = self.db_crate.row_ident();
+        let error_type = self.db_crate.error_ident();
+
+        quote! {
+            pub(crate) fn from_row(row: &#row_type) -> Result<Self, #error_type> {
+                Ok(#ident {
+                    #field_assignments
+                })
+            }
+        }
     }
 }


### PR DESCRIPTION
## 概要

struct-based APIの実装とデータベースクレート型生成問題の修正を完了しました。

## 主要な変更点

### 🚀 新機能
- **PostgresStructApi**: ゼロコスト抽象化によるstruct-based API実装
- **PostgresBuilderGen**: 将来のtyped-builderパターン対応基盤

### 🔧 修正
- **データベースクレート型生成**: 全クレートで正確な型生成
- **copy_types最適化統合**: Cow<'a, T>による効率的なパラメータ渡し
- **from_rowメソッド**: コード重複排除

### ✅ 後方互換性
- 既存APIは内部でstruct APIを使用し、破壊的変更なし
- 全QueryAnnotation対応 (:one, :many, :exec)

## 技術的成果

- **ゼロコスト抽象化**: Copy型は値渡し、非Copy型はCow最適化
- **型安全性向上**: 全データベースクレートでの正確な型生成
- **保守性向上**: 構造化されたパラメータ管理

## 対応データベースクレート

- ✅ **tokio_postgres**: `tokio_postgres::Row`, `tokio_postgres::Error`
- ✅ **postgres**: `postgres::Row`, `postgres::Error`
- ✅ **deadpool_postgres**: `deadpool_postgres::tokio_postgres::Row`

## テスト結果

```
✅ 全サンプルプロジェクトコンパイル成功
✅ 全テストケース通過  
✅ lintチェック通過
✅ WASM生成成功
```

## 今後の計画

- typed-builderパターンの完全実装
- パフォーマンスベンチマーク
- エラーメッセージ改善

🤖 Generated with [Claude Code](https://claude.ai/code)